### PR TITLE
feat: palette, mood & style 필터 선택 해제 기능 생성

### DIFF
--- a/components/product/Filter.tsx
+++ b/components/product/Filter.tsx
@@ -1,15 +1,14 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { useSetRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { paletteAtom } from '../../states/product';
 import FilterTokens from '../../public/FilterTokens';
 import { media } from '@styles/theme';
 
 function Filter() {
-  const setPalette: any = useSetRecoilState(paletteAtom);
-  const mainSelected = useRecoilValue(paletteAtom);
+  const [palette, setPalette] = useRecoilState(paletteAtom);
   const iconTokens = FilterTokens;
-  const [selectedIdx, setSelected] = useState(mainSelected);
+  const [selectedIdx, setSelected] = useState(palette);
 
   return (
     <FilterWrap>
@@ -18,8 +17,13 @@ function Filter() {
         {iconTokens.map((token, idx) => {
           const paletteColor = token.keyword;
           const handleClick: React.MouseEventHandler<HTMLImageElement> = () => {
-            setPalette(paletteColor);
-            setSelected(paletteColor);
+            if (palette === '') {
+              setPalette(paletteColor);
+              setSelected(paletteColor);
+            } else {
+              setPalette('');
+              setSelected('');
+            }
           };
           return (
             <FilterIcon key={idx}>

--- a/components/search/SelectKeyword.tsx
+++ b/components/search/SelectKeyword.tsx
@@ -2,16 +2,15 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { media } from '@styles/theme';
 import { GetFilterList } from 'lib/api/search/getFilter';
-import { useSetRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { keywordAtom } from '../../states/search';
 
 function SelectKeyword() {
   const rawData = GetFilterList();
   const moodList: string[] = [];
   const styleList: string[] = [];
-  const setText: any = useSetRecoilState(keywordAtom);
-  const mainSelected = useRecoilValue(keywordAtom);
-  const [selectedIdx, setSelected] = useState(mainSelected[1]);
+  const [text, setText] = useRecoilState(keywordAtom);
+  const [selectedIdx, setSelected] = useState(text[1]);
 
   if (rawData.message) {
     rawData.moods.map(rawMood => moodList.push(rawMood.mood_name));
@@ -32,8 +31,14 @@ function SelectKeyword() {
               <Title>{title}</Title>
               {list.map((word, idx) => {
                 const handleClick: React.MouseEventHandler<HTMLButtonElement> = () => {
-                  setText([title, word]);
-                  setSelected(word);
+                  console.log(text);
+                  if (text?.length === 0) {
+                    setText([title, word]);
+                    setSelected(word);
+                  } else {
+                    setText([]);
+                    setSelected(null);
+                  }
                 };
                 return (
                   <KeywordBtn

--- a/states/search.ts
+++ b/states/search.ts
@@ -2,5 +2,5 @@ import { atom } from 'recoil';
 
 export const keywordAtom = atom({
   key: 'keywordAtom',
-  default: [''],
+  default: [],
 });


### PR DESCRIPTION
product page palette 및 search page mood & style 필터
이미 선택한 필터 다시 선택했을 때 선택 해제 기능 생성
선택 해제하면 원래 초깃값으로 돌아감